### PR TITLE
Added retry for adb command on exception

### DIFF
--- a/android-tv-remote.py
+++ b/android-tv-remote.py
@@ -52,7 +52,11 @@ def main():
         try:
             subprocess.check_output(['adb', 'shell', 'input', 'keyevent', sources[int(args.input)]])
         except:
-            print("Error connecting to TV")
+            try:
+                print("Can't execute adb cmd, retry...")
+                subprocess.check_output(['adb', 'shell', 'input', 'keyevent', sources[int(args.input)]])
+            except:
+                print("Error connecting to TV")
     else:
         print("Unknown input (should be a value between 1-6):", args.input)
 


### PR DESCRIPTION
My Philips Android TV's 65PUS8102 and 55PUS9104 are disabling the Ethernet after ~10min in standby.
This closes the adb connection.
When you wake the TV from standby and execute this script i got:

Connected to 192.168.0.4:5555
error: device unauthorized.
This adb server's $ADB_VENDOR_KEYS is not set
Try 'adb kill-server' if that seems wrong.
Otherwise check for a confirmation dialog on your device.
Error connecting to TV

and nothing happend, i had to execute the script again to switch inputs.
To work around this issue, i have added an retry when there is an exception.
This works reliable for me.

Please merge my PR so other's can benefit from this.

thx